### PR TITLE
Less unsafe code

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -55,7 +55,7 @@ impl Default for MessageData {
     }
 }
 
-#[derive(PartialEq)]
+#[derive(PartialEq, Debug)]
 #[repr(u8)]
 pub enum Kind {
     Invalid,
@@ -112,6 +112,29 @@ pub struct Payload {
     pub kind: Kind,
     pub state: State, //zero when signed
     pub unused: u16,  //zero when signed
+}
+
+impl Payload {
+    pub fn get_tx(&self) -> &Transaction {
+        assert_eq!(self.kind, Kind::Transaction);
+        unsafe { &self.data.tx }
+    }
+    pub fn get_tx_mut(&mut self) -> &mut Transaction {
+        assert_eq!(self.kind, Kind::Transaction);
+        unsafe { &mut self.data.tx }
+    }
+    pub fn get_sub(&self) -> &Subscriber {
+        assert_eq!(self.kind, Kind::Subscribe);
+        unsafe { &self.data.sub }
+    }
+    pub fn get_poh(&self) -> &POH {
+        assert_eq!(self.kind, Kind::Signature);
+        unsafe { &self.data.poh }
+    }
+    pub fn get_get(&self) -> &GetLedger {
+        assert_eq!(self.kind, Kind::GetLedger);
+        unsafe { &self.data.get }
+    }
 }
 
 #[derive(Copy, Clone)]

--- a/src/hasht.rs
+++ b/src/hasht.rs
@@ -25,11 +25,9 @@ where
         let st = key.start();
         for i in 0..num_elems {
             let pos = st.wrapping_add(i) % num_elems;
-            unsafe {
-                let k = tbl.get_unchecked(pos).key();
-                if k.unused() || k == key {
-                    return Ok(pos);
-                }
+            let k = unsafe { tbl.get_unchecked(pos).key() };
+            if k.unused() || k == key {
+                return Ok(pos);
             }
         }
         Err(Error::NoSpace)

--- a/src/ledger.rs
+++ b/src/ledger.rs
@@ -33,7 +33,7 @@ impl Ledger {
     }
     fn exec(&self, sock: &UdpSocket, m: &data::Message) -> Result<()> {
         if let data::Kind::GetLedger = m.pld.kind {
-            let get = unsafe { &m.pld.data.get };
+            let get = &m.pld.get_get();
             self.get_ledger(sock, get)?;
         }
         Ok(())

--- a/src/net.rs
+++ b/src/net.rs
@@ -82,15 +82,13 @@ pub fn read(socket: &UdpSocket, messages: &mut [Message], num: &mut usize) -> Re
     let sz = size_of::<Message>();
     let max = messages.len();
     while *num < max {
-        unsafe {
-            let p = &mut messages[*num] as *mut Message;
-            if (max - *num) * sz < MAX_PACKET {
-                return Ok(());
-            }
-            let buf = transmute(from_raw_parts(p as *mut u8, MAX_PACKET));
-            let (nrecv, _from) = socket.recv_from(buf)?;
-            *num = *num + nrecv / sz;
+        let p = &mut messages[*num] as *mut Message;
+        if (max - *num) * sz < MAX_PACKET {
+            return Ok(());
         }
+        let buf = unsafe { transmute(from_raw_parts(p as *mut u8, MAX_PACKET)) };
+        let (nrecv, _from) = socket.recv_from(buf)?;
+        *num = *num + nrecv / sz;
     }
     Ok(())
 }


### PR DESCRIPTION
Simulate safe enums with tagged unions. The assertions allow us
to tuck away the unsafe union access so that each consumer
doen't need to wrap those accessers with `unsafe`.